### PR TITLE
[FEAT] #67 - before user network & add friend

### DIFF
--- a/app/src/main/java/org/cardna/data/remote/api/ApiService.kt
+++ b/app/src/main/java/org/cardna/data/remote/api/ApiService.kt
@@ -41,7 +41,7 @@ class AppInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain)
             : okhttp3.Response = with(chain) {
         val newRequest = request().newBuilder()
-            .addHeader("token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZW1haWwiOiJzb2xAZ21haWwuY29tIiwibmFtZSI6IuyGlCIsImZpcmViYXNlSWQiOiJFdWtjU251MDJwWW9yd0VEdW1nd3JtMGhmc2IyIiwiaWF0IjoxNjQyNDgxMDA2LCJleHAiOjE2NDUwNzMwMDYsImlzcyI6ImNhcmRuYSJ9.8Ow_D8Ggd48suNt0UiQgKbc1ZD0wlRphkxAupL_z1SM")
+            .addHeader("token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJtaW5qdUBnbWFpbC5jb20iLCJuYW1lIjoi66-87KO8IiwiZmlyZWJhc2VJZCI6Ilo2c1RtdDB3ZGRNN0R0cWpUc01qdTh5RGpncDEiLCJpYXQiOjE2NDI0ODYwMzEsImV4cCI6MTY0NTA3ODAzMSwiaXNzIjoiY2FyZG5hIn0.m6YBfAlYTPJgjnt2vq2-fTI9Xgqw7X9OJBKKwtYmgBE")
             .build()
         proceed(newRequest)
     }

--- a/app/src/main/java/org/cardna/data/remote/api/CardService.kt
+++ b/app/src/main/java/org/cardna/data/remote/api/CardService.kt
@@ -9,14 +9,15 @@ import org.cardna.data.remote.model.mypage.ResponseCreateCardYouData
 import retrofit2.http.*
 
 interface CardService {
-    // 대표 카드 조회
 
-    @GET("card/main/{userId}")
+    //타인의 대표카드 조회
+     @GET("card/main/{userId}")
     suspend fun getMainCard(
         @Path("userId")
         userId: Int?
     ): ResponseMainCardData
 
+    //자신의의 대표드 조회
     @GET("card/main")
     suspend fun getUserMainCard(): ResponseMainCardData
 

--- a/app/src/main/java/org/cardna/ui/maincard/MainCardFragment.kt
+++ b/app/src/main/java/org/cardna/ui/maincard/MainCardFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.core.text.set
 import androidx.core.text.toSpannable
 import androidx.lifecycle.lifecycleScope
@@ -19,7 +20,11 @@ import org.cardna.base.baseutil.BaseViewUtil
 import org.cardna.data.remote.api.ApiService
 import org.cardna.data.remote.model.maincard.MainCardList
 import org.cardna.databinding.FragmentMainCardBinding
+import org.cardna.ui.cardpack.CardPackFragment
 import org.cardna.ui.maincard.adapter.MainCardAdapter
+import org.cardna.ui.mypage.OtherCardCreateActivity
+import org.cardna.ui.mypage.OtherWriteActivity
+import org.cardna.ui.representcardedit.RepresentCardEditActivity
 import org.cardna.util.LinearGradientSpan
 import kotlin.math.roundToInt
 
@@ -34,17 +39,39 @@ class MainCardFragment :
     }
 
     override fun initView() {
-        // initClickEventCardYou()
         initNetwork()
         setTextGradient()
-        //initClickEventCardMe()
     }
 
+    //네트워크 통신으로 뿌려줄 리스트 초기화
     private fun initNetwork() {
+        var id: Int?
+        if (getArguments() != null) {
+            id = getArguments()?.getInt("id", 0) ?: 0
+            SeeOtherNetwork(id)
+        } else {
+            SeeMeNetwork()
+        }
+    }
+
+    private fun SeeOtherNetwork(id: Int) {
         lifecycleScope.launch {
             try {
-                list = ApiService.cardService.getMainCard(1).data.mainCardList
+                list = ApiService.cardService.getMainCard(id).data.mainCardList
                 initAdapter(list)
+                initClickEventCardYou(id)
+            } catch (e: Exception) {
+                Log.d("실패", e.message.toString())
+            }
+        }
+    }
+
+    private fun SeeMeNetwork() {
+        lifecycleScope.launch {
+            try {
+                list = ApiService.cardService.getUserMainCard().data.mainCardList
+                initAdapter(list)
+                initClickEventCardMe()
             } catch (e: Exception) {
                 Log.d("실패", e.message.toString())
             }
@@ -114,7 +141,7 @@ class MainCardFragment :
         binding.tvMaincardGotoCardpack.text = spannable
     }
 
-/*    //내가 내 메인카드 볼떄 화면
+    //내가 내 메인카드 볼떄 화면
     private fun initClickEventCardMe() {
         with(binding) {
             //카드팩 보러가기 버튼 없애기
@@ -122,49 +149,73 @@ class MainCardFragment :
             ivMaincardGotoCardpackBackground.visibility = View.GONE
 
             //친구추가 버튼 없애기
-            ibtnMaincardFriend.visibility = View.GONE
+            ctvMaincardFriend.visibility = View.GONE
 
-            //클릭 이벤트 달기
+            //연필->알림으로 바꾸기
+            ibtnMaincardAlarm.setBackgroundResource(R.drawable.ic_alarm)
+
+            //대표카드 수정 페이지로 이동
             llMaincardEditLayout.setOnClickListener {
                 val intent = Intent(requireActivity(), RepresentCardEditActivity::class.java)
                 startActivity(intent)
             }
+
+            //알림 페이지로 이동
             ibtnMaincardAlarm.setOnClickListener {
                 val intent = Intent(requireActivity(), AlarmActivity::class.java)
                 startActivity(intent)
             }
+
         }
     }
 
     //타인이 내 메인카드 볼때 화면
-    private fun initClickEventCardYou() {
-        var id: Int
+    private fun initClickEventCardYou(id: Int) {
         var name = ""
+        var sentence = ""
         if (getArguments() != null) {
             name = getArguments()?.getString("name") ?: ""
+            sentence = getArguments()?.getString("sentence") ?: ""
             binding.tvMaincardUserName.setText(name + "님은")
+            binding.tvMaincardTitle.setText(sentence)
         }
-        //넘어온 user id에 따른 대표카드 list보여주기
-        //fun requestFriendMainCard
-
         with(binding) {
             //카드팩 보러가기 버튼 보이기
             tvMaincardGotoCardpack.visibility = View.VISIBLE
             ivMaincardGotoCardpackBackground.visibility = View.VISIBLE
 
+            //edittext 버튼 없애기
+            llMaincardEditLayout.visibility = View.INVISIBLE
 
-            //친구추가 아이콘 보이기
-            ibtnMaincardFriend.visibility = View.VISIBLE
+            //친구추가 클릭
+            ctvMaincardFriend.setOnClickListener {
+                ctvMaincardFriend.toggle()
+                //친구 추가하는 네트워크 통신
+            }
 
-            //카드 작성하기 아이콘 보이기
-            ibtnMaincardAlarm.setImageResource(R.drawable.ic_mypage_write)
+            //카드너 작성하기 페이지로 이동
+            ibtnMaincardAlarm.setOnClickListener {
+                val intent = Intent(requireActivity(), OtherCardCreateActivity::class.java).apply {
+                    //현재 사용자의 name값을 전달해줘야하나? 토큰으로 못가져오나..
+                    putExtra("name", name)
+                    putExtra("id", id)
+                }
+                startActivity(intent)
+            }
+
+            //카드팩 보러갈떄 유저 id bundle로 넘김
+            tvMaincardGotoCardpack.setOnClickListener {
+                val bundle = Bundle()
+                bundle.putInt("id", id)
+
+                val cardPackFragment = CardPackFragment()
+                cardPackFragment.setArguments(bundle)
+
+                val transaction = requireActivity().supportFragmentManager.beginTransaction()
+                    .addToBackStack(null)
+                    .replace(R.id.fcv_main, cardPackFragment)
+                transaction.commit()
+            }
         }
-        //클릭 이벤트 달기
-        binding.tvMaincardGotoCardpack.setOnClickListener {
-            val transaction = requireActivity().supportFragmentManager.beginTransaction()
-                .addToBackStack(null)
-                .replace(org.cardna.R.id.fcv_main, CardPackFragment())
-            transaction.commit()
-        }
-    }*/
+    }
 }

--- a/app/src/main/java/org/cardna/ui/maincard/ResponseWrapperData.kt
+++ b/app/src/main/java/org/cardna/ui/maincard/ResponseWrapperData.kt
@@ -1,8 +1,0 @@
-package org.cardna.ui.maincard
-
-data class ResponseWrapperData<T>(
-    val status: Int,
-    val success: Boolean,
-    val message: String,
-    val data: T? = null
-)

--- a/app/src/main/java/org/cardna/ui/maincard/adapter/MainCardAdapter.kt
+++ b/app/src/main/java/org/cardna/ui/maincard/adapter/MainCardAdapter.kt
@@ -3,6 +3,7 @@ package org.cardna.ui.maincard.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import org.cardna.R
 import org.cardna.data.remote.model.detail.ResponseDetailData
 import org.cardna.data.remote.model.maincard.MainCard
@@ -19,7 +20,8 @@ class MainCardAdapter(
     inner class MainCardViewHolder(private val binding: ItemMainCardViewBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: MainCardList) {
-            // binding.ivMainCardImage.setImageResource(data.cardImg)
+            //상단 이름, 타이틀, 이미지
+            Glide.with(itemView.context).load(data.cardImg).into(binding.ivMainCardImage)
             binding.tvMainCardTitle.text = data.title
 
             //카드 너, 나에 따라 데이터 색상값 변경

--- a/app/src/main/java/org/cardna/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/org/cardna/ui/mypage/MyPageFragment.kt
@@ -37,17 +37,18 @@ class MyPageFragment : BaseViewUtil.BaseFragment<FragmentMyPageBinding>(org.card
     private fun myPageRecyclerViewAdapter() {
         val myPageFriendAdapter = MyPageFriendAdapter(
             listOf(
-                ResponseMyPageFriendData(1, "다빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
-                ResponseMyPageFriendData(1, "라빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
-                ResponseMyPageFriendData(1, "마빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
-                ResponseMyPageFriendData(1, "바빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
-                ResponseMyPageFriendData(1, "사빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
-                ResponseMyPageFriendData(1, "아빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이")
+                ResponseMyPageFriendData(3, "다빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
+                ResponseMyPageFriendData(3, "라빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
+                ResponseMyPageFriendData(3, "마빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
+                ResponseMyPageFriendData(3, "바빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
+                ResponseMyPageFriendData(3, "사빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이"),
+                ResponseMyPageFriendData(3, "아빈", org.cardna.R.drawable.img_searchemail_friend_image, "하이")
             )
         ) { item ->
             val bundle = Bundle()
             bundle.putInt("id", item.id)
             bundle.putString("name", item.name)
+            bundle.putString("sentence", item.sentence)
 
             val mainCardFragment = MainCardFragment()
             mainCardFragment.setArguments(bundle)

--- a/app/src/main/java/org/cardna/ui/mypage/OtherCardCreateActivity.kt
+++ b/app/src/main/java/org/cardna/ui/mypage/OtherCardCreateActivity.kt
@@ -19,6 +19,11 @@ class OtherCardCreateActivity :
     }
 
     private fun setListener() {
+
+        val name = intent.getStringExtra("name")
+        val id = intent.getIntExtra("id", 0)
+        binding.tvOthercardcreateRelation.text = "당신은 ${name}님에게 어떤 사람인가요 ?"
+
         binding.btnOthercardcreateNext.setOnClickListener {
             // editText 값이 들어가있으면 버튼 클릭할 수 있도록
 

--- a/app/src/main/res/drawable/selector_add_friend.xml
+++ b/app/src/main/res/drawable/selector_add_friend.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_mypage_friend_unchecked" android:state_checked="false" />
+    <item android:drawable="@drawable/ic_mypage_friend_checked" android:state_checked="true" />
+</selector>

--- a/app/src/main/res/layout/fragment_main_card.xml
+++ b/app/src/main/res/layout/fragment_main_card.xml
@@ -20,16 +20,17 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="20dp"
-            android:background="@drawable/ic_alarm"
+            android:background="@drawable/ic_mypage_write"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/ibtn_maincard_friend"
+        <CheckedTextView
+            android:id="@+id/ctv_maincard_friend"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="24dp"
-            android:background="@drawable/ic_mypage_friend_unchecked"
+            android:checked="false"
+            android:checkMark="@drawable/selector_add_friend"
             app:layout_constraintBottom_toBottomOf="@+id/ibtn_maincard_alarm"
             app:layout_constraintEnd_toStartOf="@+id/ibtn_maincard_alarm"
             app:layout_constraintTop_toTopOf="@+id/ibtn_maincard_alarm" />


### PR DESCRIPTION
## 💡 관련 이슈
#67 


## 📌 PR 내용
- [ ] 메인카드에서 user의 상단 정보를 띄우는 부분, 친구추가 아이콘을 누르면 통신되는 부분을 제외한 
layout 재사용, 클릭 이벤트 처리 완료했습니다

